### PR TITLE
Throw NoSuchMethodError if the caller requests a nonexistent member

### DIFF
--- a/lib/runtime/entity/dynamic.dart
+++ b/lib/runtime/entity/dynamic.dart
@@ -29,7 +29,7 @@ class DynamicEntity extends RawEntity {
         // about the type of the named arguments map.
         Map<String, dynamic> namedArgs = {};
         for (key in invocation.namedArguments.keys) {
-          namedArgs[key.toString()] = invocation.namedArguments[key];
+          namedArgs[MirrorSystem.getName(key)] = invocation.namedArguments[key];
         }
         throw new NoSuchMethodError(this, memberName,
             invocation.positionalArguments, namedArgs);


### PR DESCRIPTION
Angular--and potentially other callers--expect that when a method such
as containsKey is called on a DynamicEntity, that the object will throw
NoSuchMethodError. DynamicEntity, on the other hand, wants to ensure
that no one stashes a completion in a DynamicEntity and tries to call
it later. This patch accomodates both needs.
