### PR TITLE
Work around the lack of response headers

### DIFF
--- a/lib/runtime/proxy.dart
+++ b/lib/runtime/proxy.dart
@@ -15,13 +15,13 @@ class ProxyClient extends RequestHandler {
     return httpHandler.request(url, req.httpMethod, payload: payload).then((resp) {
       if (resp.statusCode != 200) {
         Map jsonError = null;
-        // TODO(gadams): There isn't currently a way to get the reponse headers.
-        // When that facility becomes available, use it to check that the
-        // content type is actually "application/json" before trying to parse.
-        try {
-          jsonError = parse(resp.body);
-        } catch(_) {
-          // Apparently, the body wan't JSON. The caller will have to make do.
+        // If the bodyType is not available, optimistically try parsing it as JSON.
+        if (resp.bodyType == null || resp.bodyType.startsWith('application/json')) {
+          try {
+            jsonError = parse(resp.body);
+          } catch(_) {
+            // Apparently, the body wan't JSON. The caller will have to make do.
+          }
         }
         throw new ProxyException(
             'API call returned status: ${resp.statusText}', resp.statusCode,


### PR DESCRIPTION
When Streamy is handling an error response, the response body may be
in JDON format, but there's currently no access to the Content-Type
header to check. So, just try to parse it to find out.
