### PR TITLE
dart:io Path deprecated, use path package

### DIFF
--- a/bin/generate_test_clients.dart
+++ b/bin/generate_test_clients.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:json';
+import 'package:path/path.dart';
 import 'package:streamy/generator.dart';
 
 /// Generates test clients defined by JSON in test/generated folder.
@@ -28,7 +29,8 @@ main() {
       print('Processing addendum: $testJsonFile');
       addendumData = parse(addendumFile.readAsStringSync());
     }
-    String generatedCode = g.generate(new Path(basePath).filename, d, addendumData: addendumData);
+    String filename = basename(basePath);
+    String generatedCode = g.generate(filename, d, addendumData: addendumData);
     testClientFile.writeAsString(generatedCode);
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,5 +12,8 @@ homepage: https://github.com/google/streamy-dart
 dependencies:
   mustache: ">=0.1.5"
   args: any
-  unittest: any
   meta: any
+dev_dependencies:
+  path: any
+  unittest: any
+


### PR DESCRIPTION
Fix for removal of Path from dart:io.
[Message to dart-announce](https://groups.google.com/a/dartlang.org/forum/#!topic/announce/KFI6XJijcic).
