### PR TITLE
sublist instead of resize when trimming HTTP body

### DIFF
--- a/lib/runtime/http.dart
+++ b/lib/runtime/http.dart
@@ -160,7 +160,7 @@ String _trimBody(String body, int byteLength) {
   if (bytes.length <= byteLength) {
     return body;
   }
-  bytes.length = byteLength;
+  bytes = bytes.sublist(0, byteLength);
   return _UTF8.decoder.convert(bytes);
 }
 


### PR DESCRIPTION
In Dart 1.2.0 UTF8 converter will return non-growable byte array. This
fix works in both 1.2.0_dev.4.0 and current stable 1.1.3.
