### PR TITLE
nit readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Find one for the API you want to access. Let's use Google URL shortener as examp
 
     > dart bin/apigen.dart \
         --discovery-file=urlshortener.json \
-        --client-file-name=urlshortener.dart \
+        --client-file-name=urlshortener \
         --output-dir=urlshortener
 
 #### What just happened?


### PR DESCRIPTION
If added the `.dart` then the urlshortener file will be `urlshortener.dart.dart`
