### PR TITLE
Adding a toString() method to StreamyRpcException

### DIFF
--- a/lib/runtime/error.dart
+++ b/lib/runtime/error.dart
@@ -20,7 +20,7 @@ class StreamyRpcException implements Exception {
   StreamyRpcException(this.httpStatus, this.request, this.response);
 
   @override
-  String toString() => response.toString();
+  String toString() => response == null ? "Instance of '${this.runtimeType}'" : response.toString();
 }
 
 typedef Future<bool> RetryStrategy(Request request, int retryNum, e);


### PR DESCRIPTION
This will make more readable asynchronous exceptions.
