### PR TITLE
Local field type fix.

### DIFF
--- a/lib/runtime/entity/base.dart
+++ b/lib/runtime/entity/base.dart
@@ -54,7 +54,7 @@ abstract class Entity {
   Map toJson();
 
   /// Local data associated with this entity instance.
-  Map<String, dynamic> get local;
+  ObservableMap<String, dynamic> get local;
 
   /// Return the Streamy implementation type of this entity.
   Type get streamyType;

--- a/lib/runtime/entity/empty.dart
+++ b/lib/runtime/entity/empty.dart
@@ -10,7 +10,7 @@ class EmptyEntity extends Entity {
   const EmptyEntity._useFactoryInstead() : super.base();
 
   /// Local data associated with this entity instance.
-  Map<String, dynamic> get local => null;
+  ObservableMap<String, dynamic> get local => null;
 
   bool get isFrozen => true;
 


### PR DESCRIPTION
Field local of type Entity implements `ObservableMap<String, dynamic>`, not `Map`.
