### PR TITLE
Change streamy multiplexer to handle and forward http 204 responses

### DIFF
--- a/lib/runtime/multiplexer.dart
+++ b/lib/runtime/multiplexer.dart
@@ -226,7 +226,10 @@ class Multiplexer extends RequestHandler {
       return;
     }
 
-    response.entity._freeze();
+    // response.entity can be null for 204s
+    if (response.entity != null) {
+      response.entity._freeze();
+    }
 
     // Publish this new entity on every channel.
     _activeIndex[request].forEach((act) =>

--- a/test/runtime/multiplexer_test.dart
+++ b/test/runtime/multiplexer_test.dart
@@ -6,6 +6,18 @@ import 'package:unittest/unittest.dart';
 
 main() {
  group('Multiplexer', () {
+    test('handles 204 responses (null entity) gracefully', () {
+      // the responses should be forward as is
+      var resp = new Response(null, Source.RPC, 0);
+      Request req = new TestRequest('GET');
+      var testHandler = (testRequestHandler()..value(resp)).build();
+      var subject = new Multiplexer(testHandler);
+      subject.handle(req, const NoopTrace()).listen(expectAsync1((actual) {
+        expect(actual.entity, isNull);
+        expect(actual.source, Source.RPC);
+        expect(actual.authority, Authority.PRIMARY);
+      }, count: 1));
+    });
     test('does not throw on error but forward to error catchers', () {
       var testHandler = (
           testRequestHandler()


### PR DESCRIPTION
In this particular case, the response entity is null.

(addresses https://github.com/google/streamy-dart/issues/217)
