### PR TITLE
Support sub-resources in discovery API generation

### DIFF
--- a/lib/templates/lazy_resource_getter.mustache
+++ b/lib/templates/lazy_resource_getter.mustache
@@ -1,6 +1,6 @@
 {
   if ({{field}} == null) {
-    {{field}} = new {{resource}}(this as streamy.Root);
+    {{field}} = new {{resource}}({{root}});
   }
   return {{field}};
 }

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -5,6 +5,7 @@ import 'base_test.dart' as base_test;
 import 'generated/addendum_test.dart' as generated_addendum_test;
 import 'generated/handler_test.dart' as generated_handler_test;
 import 'generated/method_get_test.dart' as generated_method_get_test;
+import 'generated/nested_resources_test.dart' as generated_nested_resources_test;
 import 'generated/method_post_test.dart' as generated_method_post_test;
 import 'generated/method_params_test.dart' as generated_method_params_test;
 import 'generated/proto_test.dart' as generated_proto_test;
@@ -43,6 +44,7 @@ main(List<String> args) {
   generated_method_get_test.main();
   generated_method_post_test.main();
   generated_method_params_test.main();
+  generated_nested_resources_test.main();
   generated_proto_test.main();
   generated_schema_object_test.main();
 

--- a/test/generated/nested_resources_test.dart
+++ b/test/generated/nested_resources_test.dart
@@ -1,0 +1,39 @@
+library streamy.generated.method_get.test;
+
+import 'dart:async';
+import 'package:unittest/unittest.dart';
+import 'package:streamy/streamy.dart';
+import 'nested_resources_client.dart';
+import 'nested_resources_client_requests.dart';
+import 'nested_resources_client_resources.dart';
+import 'nested_resources_client_objects.dart';
+import 'nested_resources_client_dispatch.dart';
+
+main() {
+  group('NestedResourcesTest', () {
+    test('Generates top-level resources', () {
+      var subject = new NestedResourcesTest(null);
+      expect(subject.foos.runtimeType, equals(FoosResource));
+    });
+    test('Generates second-level resources', () {
+      var subject = new NestedResourcesTest(null);
+      expect(subject.foos.bars.runtimeType, equals(FoosBarsResource));
+    });
+    test('Generates third-level resources', () {
+      var subject = new NestedResourcesTest(null);
+      expect(subject.foos.bars.bazes.runtimeType, equals(FoosBarsBazesResource));
+    });
+    test('Generates methods for top-level resources', () {
+      var subject = new NestedResourcesTest(null);
+      expect(subject.foos.get(1).httpMethod, equals('GET'));
+    });
+    test('Generates methods for second-level resources', () {
+      var subject = new NestedResourcesTest(null);
+      expect(subject.foos.bars.get(1, 2).httpMethod, equals('GET'));
+    });
+    test('Generates methods for third-level resources', () {
+      var subject = new NestedResourcesTest(null);
+      expect(subject.foos.bars.bazes.get(1, 2, 3).httpMethod, equals('GET'));
+    });
+  });
+}

--- a/test/generated/nested_resources_test.json
+++ b/test/generated/nested_resources_test.json
@@ -1,0 +1,129 @@
+{
+  "name": "NestedResourcesTest",
+  "servicePath": "nestedResourcesTest/v1/",
+  "schemas": {
+    "Foo": {
+      "id": "Foo",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Primary key."
+        }
+      }
+    },
+    "Bar": {
+      "id": "Bar",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Primary key."
+        }
+      }
+    },
+    "Baz": {
+      "id": "Baz",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Primary key."
+        }
+      }
+    }
+  },
+  "resources": {
+    "foos": {
+      "methods": {
+        "get": {
+          "id": "service.foos.get",
+          "path": "foos/{fooId}",
+          "name": "",
+          "response": {
+            "$ref": "Foo"
+          },
+          "httpMethod": "GET",
+          "description": "Gets a foo",
+          "parameters": {
+            "fooId": {
+              "type": "integer",
+              "description": "Primary key of foo",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": ["fooId"]
+        }
+      },
+      "resources": {
+        "bars": {
+          "methods": {
+            "get": {
+              "id": "service.foos.bars.get",
+              "path": "foos/{fooId}/bars/{barId}",
+              "name": "",
+              "response": {
+                "$ref": "Bar"
+              },
+              "httpMethod": "GET",
+              "description": "Gets a bar",
+              "parameters": {
+                "fooId": {
+                  "type": "integer",
+                  "description": "Primary key of foo",
+                  "required": true,
+                  "location": "path"
+                },
+                "barId": {
+                  "type": "integer",
+                  "description": "Primary key of bar",
+                  "required": true,
+                  "location": "path"
+                }
+              },
+              "parameterOrder": ["fooId", "barId"]
+            }
+          },
+          "resources": {
+            "bazes": {
+              "methods": {
+                "get": {
+                  "id": "service.foos.bars.bazes.get",
+                  "path": "foos/{fooId}/bars/{barId}/bazesbaz/{bazId}",
+                  "name": "",
+                  "response": {
+                    "$ref": "Bar"
+                  },
+                  "httpMethod": "GET",
+                  "description": "Gets a baz",
+                  "parameters": {
+                    "fooId": {
+                      "type": "integer",
+                      "description": "Primary key of foo",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "barId": {
+                      "type": "integer",
+                      "description": "Primary key of bar",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "bazId": {
+                      "type": "integer",
+                      "description": "Primary key of baz",
+                      "required": true,
+                      "location": "path"
+                    }
+                  },
+                  "parameterOrder": ["fooId", "barId", "bazId"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/generated/nested_resources_test.streamy.yaml
+++ b/test/generated/nested_resources_test.streamy.yaml
@@ -1,0 +1,12 @@
+discovery: nested_resources_test.json
+output:
+  files: split
+  prefix: nested_resources_client
+base:
+  class: Entity
+  import: package:streamy/base.dart
+  backing: map
+options:
+  clone: true
+  removers: true
+  known: false


### PR DESCRIPTION
This prefixes resource names with the name of their parent resource, which can lead to some unwieldy Resource and Request class names; it's an easier way to disambiguate than splitting into more libraries still (which would be a substantial refactor, I believe).

This is a clone of https://github.com/google/streamy-dart/pull/234, on the new master branch.
