### PR TITLE
Fix a discovery generation bug where fields that are types with illegal class names cause broken generated code

### DIFF
--- a/lib/generator/emitter.dart
+++ b/lib/generator/emitter.dart
@@ -731,7 +731,7 @@ class EmitterContext {
     clazz.methods.add(new DartMethod('unmarshal$name', type,
         new DartTemplateBody(unmarshal, serializerConfig))
       ..parameters.add(new DartParameter('data', rt)));
-    clazz.methods.add(new DartMethod('_handle$name', const DartType.dynamic(), new DartTemplateBody(_template('marshal_handle'), {
+    clazz.methods.add(new DartMethod(makeHandlerName(schema.name), const DartType.dynamic(), new DartTemplateBody(_template('marshal_handle'), {
         'type': name
       }), isStatic: true)
         ..parameters.add(new DartParameter('marshaller', new DartType('Marshaller', null, const [])))

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -7,6 +7,7 @@ import 'generated/handler_test.dart' as generated_handler_test;
 import 'generated/identifier_name_test.dart' as generated_identifier_name_test;
 import 'generated/method_get_test.dart' as generated_method_get_test;
 import 'generated/nested_resources_test.dart' as generated_nested_resources_test;
+import 'generated/illegal_names_test.dart' as generated_illegal_names_test;
 import 'generated/method_post_test.dart' as generated_method_post_test;
 import 'generated/method_params_test.dart' as generated_method_params_test;
 import 'generated/proto_test.dart' as generated_proto_test;
@@ -43,6 +44,7 @@ main(List<String> args) {
   generated_addendum_test.main();
   generated_handler_test.main();
   generated_identifier_name_test.main();
+  generated_illegal_names_test.main();
   generated_method_get_test.main();
   generated_method_post_test.main();
   generated_method_params_test.main();

--- a/test/generated/illegal_names_test.dart
+++ b/test/generated/illegal_names_test.dart
@@ -1,0 +1,72 @@
+library streamy.generated.illegal_names.test;
+
+import 'dart:async';
+import 'package:unittest/unittest.dart';
+import 'package:streamy/streamy.dart';
+import 'illegal_names_client.dart';
+import 'illegal_names_client_requests.dart';
+import 'illegal_names_client_resources.dart';
+import 'illegal_names_client_objects.dart';
+import 'illegal_names_client_dispatch.dart';
+
+main() {
+  group('IllegalNamesTest', () {
+    test('RequestResponseCycle as response', () {
+      $Type testResponse = new $Type()..id = 1;
+      var marshaller = new Marshaller();
+      var testRequestHandler = new RequestHandler.fromFunction(
+          (req) => new Stream.fromIterable(
+              [new Response(req.unmarshalResponse(marshaller.marshal$Type(testResponse)), Source.RPC, 0)]));
+      var subject = new IllegalNamesTest(testRequestHandler);
+      subject.types.get(1).send().listen(expectAsync(($Type v) {
+        expect(marshaller.marshal$Type(v), equals(marshaller.marshal$Type(testResponse)));
+      }, count: 1));
+    });
+    test('RequestResponseCycle as field', () {
+      var type = new $Type()..id = 2;
+      Foo testResponse = new Foo()
+          ..id = 1
+          ..fooType = type;
+      var marshaller = new Marshaller();
+      var testRequestHandler = new RequestHandler.fromFunction(
+          (req) => new Stream.fromIterable(
+              [new Response(req.unmarshalResponse(marshaller.marshalFoo(testResponse)), Source.RPC, 0)]));
+      var subject = new IllegalNamesTest(testRequestHandler);
+      subject.foos.get(1).send().listen(expectAsync((Foo v) {
+        expect(marshaller.marshalFoo(v), equals(marshaller.marshalFoo(testResponse)));
+      }, count: 1));
+    });
+  });
+  group('Illegally named property apiType', () {
+    test('of Type', () {
+      expect($Type.API_TYPE, '\$Type');
+      expect(new $Type().apiType, '\$Type');
+    });
+    test('of TypesResource', () {
+      expect(TypesResource.API_TYPE, 'TypesResource');
+      expect(new IllegalNamesTest(null).types.apiType, 'TypesResource');
+    });
+    test('of TypesGetRequest', () {
+      expect(TypesGetRequest.API_TYPE, 'TypesGetRequest');
+      expect(new IllegalNamesTest(null).types.get(1).apiType, 'TypesGetRequest');
+    });
+  });
+  group('Illegally named property serialization', () {
+    test('to/from json as object', () {
+      var f = new $Type()..id = 1;
+      var m = new Marshaller();
+      var f2 = m.unmarshal$Type(m.marshal$Type(f));
+      expect(f2.id, equals(1));
+    });
+    test('to/from json as field', () {
+      var type = new $Type()..id = 2;
+      var foo = new Foo()
+          ..id = 1
+          ..fooType = type;
+      var m = new Marshaller();
+      var foo2 = m.unmarshalFoo(m.marshalFoo(foo));
+      expect(foo2.id, equals(1));
+      expect(foo2.fooType.id, equals(2));
+    });
+  });
+}

--- a/test/generated/illegal_names_test.json
+++ b/test/generated/illegal_names_test.json
@@ -1,0 +1,77 @@
+{
+  "name": "IllegalNamesTest",
+  "servicePath": "illegalNamesTest/v1/",
+  "schemas": {
+    "Type": {
+      "id": "Type",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Primary key."
+        }
+      }
+    },
+    "Foo": {
+      "id": "Foo",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Primary key."
+        },
+        "fooType": {
+          "$ref": "Type"
+        }
+      }
+    }
+  },
+  "resources": {
+    "types": {
+      "methods": {
+        "get": {
+          "id": "service.types.get",
+          "path": "types/{typeId}",
+          "name": "",
+          "response": {
+            "$ref": "Type"
+          },
+          "httpMethod": "GET",
+          "description": "Gets a type",
+          "parameters": {
+            "typeId": {
+              "type": "integer",
+              "description": "Primary key of type",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": ["typeId"]
+        }
+      }
+    },
+    "foos": {
+      "methods": {
+        "get": {
+          "id": "service.foos.get",
+          "path": "foos/{fooId}",
+          "name": "",
+          "response": {
+            "$ref": "Foo"
+          },
+          "httpMethod": "GET",
+          "description": "Gets a foo",
+          "parameters": {
+            "fooId": {
+              "type": "integer",
+              "description": "Primary key of foo",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": ["fooId"]
+        }
+      }
+    }
+  }
+}

--- a/test/generated/illegal_names_test.streamy.yaml
+++ b/test/generated/illegal_names_test.streamy.yaml
@@ -1,0 +1,12 @@
+discovery: illegal_names_test.json
+output:
+  files: split
+  prefix: illegal_names_client
+base:
+  class: Entity
+  import: package:streamy/base.dart
+  backing: map
+options:
+  clone: true
+  removers: true
+  known: false


### PR DESCRIPTION
Previously, where a schema object's name was a reserved keyword, the marshaller's helper method for it was declared as '_handle' but referenced as '_handle$'. This change makes both use '_handle'.

Clone of https://github.com/google/streamy-dart/pull/240 with commit history squashed.

FYI post-rebase it appears that test/generated/schema_object_client_objects.dart is broken - since it's broken in a clean client too I don't believe it's this change that's broken it.
