### PR TITLE
Allow slashes in the final parameter in the path if it's name begins with a '+'

### DIFF
--- a/lib/runtime/request.dart
+++ b/lib/runtime/request.dart
@@ -136,24 +136,26 @@ abstract class HttpRequest implements Request {
   String get path {
     int pos = 0;
     StringBuffer buf = new StringBuffer();
-    bool seenWildcardQueryParameter = false;
+    bool seenReservedExpansionParameter = false;
     
     for (Match m in pathRegex.allMatches(pathFormat)) {
-      if (seenWildcardQueryParameter) {
+      if (seenReservedExpansionParameter) {
         throw new StateError(
-            'Path contained wildcard parameter in non-final position');
+            'Path contained Reserved Expansion parameter in non-final position');
       }
       buf.write(pathFormat.substring(pos, m.start));
       String pathParamName = pathFormat.substring(m.start + 1, m.end - 1);
       if (pathParamName.startsWith('\+')) {
-        // A path parameter whose name starts with a + symbol is permitted to
-        // contain the '/' character, so add it back after the URI encoding has
-        // removed it.
-        // Note that wildcards can only exist as the last parameter in the path
-        // to avoid ambiguity in path matching.
+        // A path parameter whose name starts with a + symbol (known as a
+        // Reserved Expansion) is permitted to contain the '/' character, so
+        // add it back after the URI encoding has removed it
+        // (http://tools.ietf.org/html/rfc6570#section-3.2.3).
+        // Note that Reserved Expansions can only exist as the last parameter
+        // in the path to avoid ambiguity in path matching.
         var encoded = Uri.encodeComponent(
             parameters[pathParamName.substring(1)].toString());
         buf.write(encoded.replaceAll('%2F', '/'));
+        seenReservedExpansionParameter = true;
       } else {
         buf.write(Uri.encodeComponent(parameters[pathParamName].toString()));
       }

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -11,7 +11,7 @@ import 'generated/illegal_names_test.dart' as generated_illegal_names_test;
 import 'generated/method_post_test.dart' as generated_method_post_test;
 import 'generated/method_params_test.dart' as generated_method_params_test;
 import 'generated/schema_object_test.dart' as generated_schema_object_test;
-import 'generated/wildcard_path_param_test.dart' as generated_wildcard_path_param_test;
+import 'generated/reserved_expansion_path_param_test.dart' as generated_reserved_expansion_path_param_test;
 
 import 'mixins/dot_access_test.dart' as mixins_dot_access_test;
 import 'mixins/immutable_test.dart' as mixins_immutable_test;
@@ -50,7 +50,7 @@ main(List<String> args) {
   generated_method_params_test.main();
   generated_nested_resources_test.main();
   generated_schema_object_test.main();
-  generated_wildcard_path_param_test.main();
+  generated_reserved_expansion_path_param_test.main();
 
   mixins_dot_access_test.main();
   mixins_immutable_test.main();

--- a/test/generated/reserved_expansion_path_param_test.dart
+++ b/test/generated/reserved_expansion_path_param_test.dart
@@ -1,17 +1,17 @@
-library streamy.generated.wildcard_path_param.test;
+library streamy.generated.reserved_expansion_path_param.test;
 
 import 'package:unittest/unittest.dart';
-import 'wildcard_path_param_client_requests.dart';
+import 'reserved_expansion_path_param_client_requests.dart';
 
 main() {
-  group('WildcardPathParamTest', () {
-    test('Wildcard path parameter contains a slash', () {
+  group('ReservedExpansionPathParamTest', () {
+    test('Reserved Expansion path parameter may contain a slash', () {
       var req = new FoosGetRequest(null)
         ..barId = 'abc'
         ..fooId = 'def/ghi';
       expect(req.path, equals('foos/abc/def/ghi'));
     });
-    test('Wildcard path parameter does not contain a slash', () {
+    test('Reserved Expansion path parameter does require a slash', () {
       var req = new FoosGetRequest(null)
         ..barId = 'abc'
         ..fooId = 'def';

--- a/test/generated/reserved_expansion_path_param_test.json
+++ b/test/generated/reserved_expansion_path_param_test.json
@@ -1,6 +1,6 @@
 {
-  "name": "WildcardPathParamTest",
-  "servicePath": "wildcardPathParamTest/v1/",
+  "name": "ReservedExpansionPathParamTest",
+  "servicePath": "reservedExpansionPathParamTest/v1/",
   "resources": {
     "foos": {
       "methods": {

--- a/test/generated/reserved_expansion_path_param_test.streamy.yaml
+++ b/test/generated/reserved_expansion_path_param_test.streamy.yaml
@@ -1,7 +1,7 @@
-discovery: wildcard_path_param_test.json
+discovery: reserved_expansion_path_param_test.json
 output:
   files: split
-  prefix: wildcard_path_param_client
+  prefix: reserved_expansion_path_param_client
 base:
   class: Entity
   import: package:streamy/base.dart

--- a/test/runtime/request_test.dart
+++ b/test/runtime/request_test.dart
@@ -29,9 +29,9 @@ class RequestWithPathParams extends HttpRequest {
   List<String> get queryParameters => [];
 }
 
-class RequestWithWildcardPathParams extends HttpRequest {
+class RequestWithReservedExpansionPathParam extends HttpRequest {
 
-  RequestWithWildcardPathParams() : super(null);
+  RequestWithReservedExpansionPathParam() : super(null);
   Request clone() => null;
   bool get hasPayload => false;
   String get httpMethod => null;
@@ -60,8 +60,8 @@ main() {
         ..localParameters["baz"] = 'test2';
       expect(req.path, "/test?foo=test1&baz=test2");
     });
-    test("should allow slashes in wildcard path parameters", () {
-      var req = new RequestWithWildcardPathParams()
+    test("should allow slashes in Reserved Expansion path parameters", () {
+      var req = new RequestWithReservedExpansionPathParam()
         ..parameters["bar"] = "a@b/c&d";
       expect(req.path, "/test/a%40b/c%26d"); // slashes allowed
     });


### PR DESCRIPTION
We've run into this with our own Discovery-enabled API, and while we could in theory deal with the unescaping server-side it'd be messy and we'd still have to handle mapping the parameter names correctly.

Per previous discussions, I think a new test under test/generated is the right thing to do - let me know if you'd rather I rolled it into an existing test.
