### PR TITLE
When creating a DartType for a list field, pass the withPrefix parameter...

### DIFF
--- a/lib/generator/emitter_util.dart
+++ b/lib/generator/emitter_util.dart
@@ -39,7 +39,7 @@ abstract class EmitterBase {
 
   DartType toDartType(TypeRef ref, {bool withPrefix: true}) {
     if (ref is ListTypeRef) {
-      return new DartType.list(toDartType(ref.subType));
+      return new DartType.list(toDartType(ref.subType, withPrefix: withPrefix));
     } else if (ref is SchemaTypeRef) {
       final prefix = withPrefix ? objectPrefix : null;
       return new DartType(makeClassName(ref.schemaClass), prefix, const []);


### PR DESCRIPTION
... to the recursive call so we don't end up incorrectly qualifying the generic type.
