### PR TITLE
test detachment of plain lists from observable list

### DIFF
--- a/test/generated/schema_object_test.dart
+++ b/test/generated/schema_object_test.dart
@@ -179,6 +179,14 @@ main() {
       expect(bar.foos[0].bar, 'hello',
           reason: 'Expected list to contain the same stuff as the original');
     });
+    test('lists are detached from observable list created by setter', () {
+      var bar = new Bar();
+      var list = [1, 2];
+      bar.foos = list;
+      list.add(3);
+      expect(bar.foos, [1, 2],
+        reason: 'setter does not wrap the list but makes a copy');
+    });
     test('observable lists not copied in setter', () {
       var bar = new Bar();
       var list = new ObservableList<Foo>();


### PR DESCRIPTION
so we do not break it accidentally
