### PR TITLE
Fix pub build error

### DIFF
--- a/lib/generator/ir.dart
+++ b/lib/generator/ir.dart
@@ -133,7 +133,7 @@ class Field {
 class TypeRef {
   final String base;
   
-  TypeRef(this.base);
+  const TypeRef(this.base);
   
   const TypeRef.integer() : this('integer');
   const TypeRef.string() : this('string');


### PR DESCRIPTION
Before
```
aam-macbookpro2:aam-streamy-dart aam$ pub build
Loading source assets... 
Loading smoke/src/default_transformer and streamy transformers... 
Building streamy... 
Build error:
Transform StreamyYaml on streamy|lib/raw.streamy.yaml threw error: 'package:streamy/generator/ir.dart': error: line 140 pos 25: redirection constructor 'TypeRef' must be const
  const TypeRef.any() : this('any');
                        ^

dart:async/zone.dart 1404                  _RootZone.runUnary
dart:async/future_impl.dart 131            _FutureListener.handleValue
dart:async/future_impl.dart 637            _Future._propagateToListeners.handleValueCallback
dart:async/future_impl.dart 667            _Future._propagateToListeners
dart:async/future_impl.dart 477            _Future._completeWithValue
dart:async/future_impl.dart 528            _Future._asyncComplete.<fn>
dart:async/schedule_microtask.dart 41      _microtaskLoop
dart:async/schedule_microtask.dart 50      _startMicrotaskLoop
dart:isolate-patch/isolate_patch.dart 96   _runPendingImmediateCallback
dart:isolate-patch/isolate_patch.dart 149  _RawReceivePortImpl._handleMessage

dart:isolate  _RawReceivePortImpl._handleMessage

Build failed.
```

After

```
aam-macbookpro2:aam-streamy-dart aam$ pub build
Loading source assets... 
Loading smoke/src/default_transformer and streamy transformers... 
Building streamy... 
Built 247 files to "build".
aam-macbookpro2:aam-streamy-dart aam$ 
```